### PR TITLE
Import InvalidStateException class

### DIFF
--- a/src/AzureOauthProvider.php
+++ b/src/AzureOauthProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\User;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
+use Laravel\Socialite\Two\InvalidStateException;
 
 class AzureOauthProvider extends AbstractProvider implements ProviderInterface
 {


### PR DESCRIPTION
Import `Laravel\Socialite\Two\InvalidStateException` to fix this error when OAuth is in an invalid state:

`Class "hakkahio\AzureSocialite\InvalidStateException" not found`

